### PR TITLE
Reset of vehicle dimensions during simulations

### DIFF
--- a/adore_if_ros/include/adore_if_ros/conversions/simresetvehicledimensionsconverter.h
+++ b/adore_if_ros/include/adore_if_ros/conversions/simresetvehicledimensionsconverter.h
@@ -1,0 +1,153 @@
+/********************************************************************************
+ * Copyright (C) 2017-2023 German Aerospace Center (DLR).
+ * Eclipse ADORe, Automated Driving Open Research https://eclipse.org/adore
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Matthias Nichting - initial API and implementation
+ ********************************************************************************/
+
+#pragma once
+#include <adore/sim/resetvehicledimensions.h>
+#include <adore_if_ros_msg/SimResetVehicleDimensions.h>
+namespace adore
+{
+    namespace if_ROS
+    {
+
+        struct SimVehicleDimensionsConverter
+        {
+            void operator()(adore_if_ros_msg::SimResetVehicleDimensionsConstPtr msg, adore::sim::ResetVehicleDimensions& rvd)
+            {
+                toOBJ(*msg, rvd);
+            }
+            void operator()(const adore_if_ros_msg::SimResetVehicleDimensions& msg,
+                            adore::sim::ResetVehicleDimensions& rvd)
+            {
+                toOBJ(msg, rvd);
+            }
+            adore_if_ros_msg::SimResetVehicleDimensions operator()(const adore::sim::ResetVehicleDimensions& rvd)
+            {
+                adore_if_ros_msg::SimResetVehicleDimensions msg;
+                toMSG(rvd, msg);
+                return msg;
+            }
+            void toMSG(const adore::sim::ResetVehicleDimensions& source,
+                       adore_if_ros_msg::SimResetVehicleDimensions& target)
+            {
+                double val;
+                if (source.get_a(val))
+                {
+                    target.a = val;
+                    target.a_valid = true;
+                }
+                else
+                {
+                    target.a_valid = false;
+                }
+                if (source.get_b(val))
+                {
+                    target.b = val;
+                    target.b_valid = true;
+                }
+                else
+                {
+                    target.b_valid = false;
+                }
+                if (source.get_c(val))
+                {
+                    target.c = val;
+                    target.c_valid = true;
+                }
+                else
+                {
+                    target.c_valid = false;
+                }
+                if (source.get_d(val))
+                {
+                    target.d = val;
+                    target.d_valid = true;
+                }
+                else
+                {
+                    target.d_valid = false;
+                }
+                if (source.get_m(val))
+                {
+                    target.m = val;
+                    target.m_valid = true;
+                }
+                else
+                {
+                    target.m_valid = false;
+                }
+                if (source.get_width(val))
+                {
+                    target.width = val;
+                    target.width_valid = true;
+                }
+                else
+                {
+                    target.width_valid = false;
+                }
+            }
+            void toOBJ(const adore_if_ros_msg::SimResetVehicleDimensions& source,
+                       adore::sim::ResetVehicleDimensions& target)
+            {
+                if (source.a_valid)
+                {
+                    target.set_a(source.a);
+                }
+                else
+                {
+                    target.invalidate_a();
+                }
+                if (source.b_valid)
+                {
+                    target.set_b(source.b);
+                }
+                else
+                {
+                    target.invalidate_b();
+                }
+                if (source.c_valid)
+                {
+                    target.set_c(source.c);
+                }
+                else
+                {
+                    target.invalidate_c();
+                }
+                if (source.d_valid)
+                {
+                    target.set_d(source.d);
+                }
+                else
+                {
+                    target.invalidate_d();
+                }
+                if (source.m_valid)
+                {
+                    target.set_m(source.m);
+                }
+                else
+                {
+                    target.invalidate_m();
+                }
+                if (source.width_valid)
+                {
+                    target.set_width(source.width);
+                }
+                else
+                {
+                    target.invalidate_width();
+                }
+            }
+        };
+    }  // namespace if_ROS
+}  // namespace adore

--- a/adore_if_ros/include/adore_if_ros/funfactory.h
+++ b/adore_if_ros/include/adore_if_ros/funfactory.h
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (C) 2017-2020 German Aerospace Center (DLR). 
+ * Copyright (C) 2017-2023 German Aerospace Center (DLR). 
  * Eclipse ADORe, Automated Driving Open Research https://eclipse.org/adore
  *
  * This program and the accompanying materials are made available under the 
@@ -236,7 +236,14 @@ namespace adore
                     return new Feed<adore::fun::PlanningResult,
                                       adore_if_ros_msg::PlanningResultConstPtr,
                                       PlanningResultConverter>(n_, "FUN/PlanningResult", 100);
-                }    
+                }
+                ///reads selected PlanningResult as general information about decision-making
+                virtual adore::mad::AFeed<adore::fun::PlanningResult>* getPlanningSelectFeed() override
+                {
+                    return new Feed<adore::fun::PlanningResult,
+                                      adore_if_ros_msg::PlanningResultConstPtr,
+                                      PlanningResultConverter>(n_, "FUN/PlanningSelect", 100);
+                }
                 virtual adore::mad::AWriter<adore::fun::PlanningRequest>* getPlanningRequestWriter() override
                 {
                     return new Writer<adore::fun::PlanningRequest,

--- a/adore_if_ros/include/adore_if_ros/simfactory.h
+++ b/adore_if_ros/include/adore_if_ros/simfactory.h
@@ -34,6 +34,7 @@
 #include "conversions/motioncommandconverter.h"
 #include "conversions/funvehiclemotionstateconverter.h"
 #include "conversions/simvehicleresetconverter.h"
+#include "conversions/simresetvehicledimensionsconverter.h"
 #include "conversions/stdconverter.h"
 #include "conversions/trafficparticipantconverter.h"
 #include "conversions/trafficsimulationfeed.h"
@@ -163,6 +164,20 @@ namespace adore
                 virtual TV2XStationIDResetFeed* getV2XStationIDResetFeed() override
                 {
                     return new Feed<int64_t,std_msgs::Int64,StdConverter>(n_,"SIM/ResetV2XStationID",10);
+                }
+                ///send simulation commands for resseting vehicle dimensions
+                virtual TVehicleDimensionsResetWriter* getVehicleDimensionsResetWriter(std::string ns) override
+                {
+                    return new Writer<adore::sim::ResetVehicleDimensions,
+                                        adore_if_ros_msg::SimResetVehicleDimensions,
+                                        SimVehicleDimensionsConverter>(n_,ns + "SIM/ResetVehicleDimensions",1);
+                }
+                ///receive simulation commands for resseting vehicle dimensions
+                virtual TVehicleDimensionsResetFeed* getVehicleDimensionsResetFeed() override
+                {
+                    return new Feed<adore::sim::ResetVehicleDimensions,
+                                        adore_if_ros_msg::SimResetVehicleDimensionsConstPtr,
+                                        SimVehicleDimensionsConverter>(n_,"SIM/ResetVehicleDimensions",1);
                 }
                 ///send simulated sensor data
                 virtual TParticipantSetWriter* getParticipantSetWriter() override

--- a/adore_if_ros/include/adore_if_ros/simfactory.h
+++ b/adore_if_ros/include/adore_if_ros/simfactory.h
@@ -156,7 +156,7 @@ namespace adore
                                     geometry_msgs::Twist,
                                     SimVehicleResetConverter>(n_,"SIM/ResetVehicleTwist",1);
                 }
-                ///send simulation commands for resseting simulation id and v2xstation id
+                ///send simulation commands for resetting simulation id and v2xstation id
                 virtual TSimulationIDResetFeed* getSimulationIDResetFeed() override
                 {
                     return new Feed<int64_t,std_msgs::Int64,StdConverter>(n_,"SIM/ResetSimulationID",10);
@@ -165,14 +165,14 @@ namespace adore
                 {
                     return new Feed<int64_t,std_msgs::Int64,StdConverter>(n_,"SIM/ResetV2XStationID",10);
                 }
-                ///send simulation commands for resseting vehicle dimensions
+                ///send simulation commands for resetting vehicle dimensions
                 virtual TVehicleDimensionsResetWriter* getVehicleDimensionsResetWriter(std::string ns) override
                 {
                     return new Writer<adore::sim::ResetVehicleDimensions,
                                         adore_if_ros_msg::SimResetVehicleDimensions,
                                         SimVehicleDimensionsConverter>(n_,ns + "SIM/ResetVehicleDimensions",1);
                 }
-                ///receive simulation commands for resseting vehicle dimensions
+                ///receive simulation commands for resetting vehicle dimensions
                 virtual TVehicleDimensionsResetFeed* getVehicleDimensionsResetFeed() override
                 {
                     return new Feed<adore::sim::ResetVehicleDimensions,


### PR DESCRIPTION
This pr adds implementations to allow resetting vehicle dimensions during simulations. 
Depends on:
https://github.com/DLR-TS/adore_if_ros_msg/pull/7
https://github.com/DLR-TS/libadore/pull/1